### PR TITLE
specify from name and email as flags

### DIFF
--- a/report/report.cfg
+++ b/report/report.cfg
@@ -1,3 +1,4 @@
 day_counts = {1, 7, 30}
 top_count = 10
 from_email = "push_metrics@mozilla.com"
+from_name = "Push Metrics"

--- a/report/report.lua
+++ b/report/report.lua
@@ -203,7 +203,6 @@ local function main()
 
     -- Add some values directly from report.cfg.
     results.top_count = top_count
-    results.from_email = from_email
 
     -- Create the top receiver count strings.
     for _, days in ipairs(day_counts) do
@@ -231,7 +230,7 @@ local function main()
     io.write(email)
 
     -- Send the email.
-    local sendmail_cmd = string.format("/usr/sbin/sendmail -vt < %s", outfile_name)
+    local sendmail_cmd = string.format("/usr/sbin/sendmail -vtF '%s' -r '%s' < '%s'", from_name, from_email, outfile_name)
     io.popen(sendmail_cmd)
 
     -- Delete file from 3 days ago, if it exists.

--- a/report/report.txt
+++ b/report/report.txt
@@ -1,5 +1,4 @@
 To: push_metrics@mozilla.com
-From: ${from_email}
 Subject: Push Endpoint server utilization metrics through ${days_ago_last}
 
 ----------------------------------------------------


### PR DESCRIPTION
`sendmail -t` will only read the recipient from headers, it will set the `From` on its own. This fixes that so emails arrive properly.

r? @rafrombrc